### PR TITLE
Append @ProcName to start of procedures

### DIFF
--- a/deployable_test.go
+++ b/deployable_test.go
@@ -1,10 +1,11 @@
 package sqlcode
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDeployable(t *testing.T) {

--- a/sqlparser/parser.go
+++ b/sqlparser/parser.go
@@ -412,8 +412,7 @@ func (d *Document) parseCreate(s *Scanner, createCountInBatch int) (result Creat
 	}
 
 	// We have matched "create <createType> [code].<quotedName>"; at this
-	// point
-	// and then copy the rest of the sql until the batch ends; *but* track dependencies
+	// point we copy the rest until the batch ends; *but* track dependencies
 	// + some other details mentioned below
 
 	startOfProcedure := true
@@ -472,7 +471,7 @@ tailloop:
 		case tt == ReservedWordToken && s.Token() == "as":
 			CopyToken(s, &result.Body)
 			NextTokenCopyingWhitespace(s, &result.Body)
-			if startOfProcedure && tt == ReservedWordToken && s.Token() != "begin" {
+			if startOfProcedure { //&& tt == ReservedWordToken && s.Token() != "begin" {
 				// Add the `ProcName` token to a procedure
 				// The `ProcName` token is just a convenience so that
 				// we can refer to the procedure's name inside the procedure
@@ -480,7 +479,7 @@ tailloop:
 				if result.CreateType == "procedure" {
 					procNameToken := Unparsed{
 						Type:     OtherToken,
-						RawValue: fmt.Sprintf("DECLARE @ProcName NVARCHAR(128)\nSET @ProcName = '%s'", strings.Trim(result.QuotedName.Value, "[]")),
+						RawValue: fmt.Sprintf("DECLARE @ProcName NVARCHAR(128)\nSET @ProcName = '%s'\n", strings.Trim(result.QuotedName.Value, "[]")),
 					}
 					result.Body = append(result.Body, procNameToken)
 				}

--- a/sqlparser/parser.go
+++ b/sqlparser/parser.go
@@ -471,11 +471,9 @@ tailloop:
 		case tt == ReservedWordToken && s.Token() == "as":
 			CopyToken(s, &result.Body)
 			NextTokenCopyingWhitespace(s, &result.Body)
-			if firstAs { //&& tt == ReservedWordToken && s.Token() != "begin" {
-				// Add the `RoutineName` token to a procedure
-				// The `RoutineName` token is just a convenience so that
-				// we can refer to the procedure/function name inside the procedure
-				// (for example, when logging)
+			if firstAs {
+				// Add the `RoutineName` token as a convenience, so that we can refer to the procedure/function name
+				// from inside the procedure (for example, when logging)
 				if result.CreateType == "procedure" {
 					procNameToken := Unparsed{
 						Type:     OtherToken,

--- a/sqlparser/parser.go
+++ b/sqlparser/parser.go
@@ -415,7 +415,7 @@ func (d *Document) parseCreate(s *Scanner, createCountInBatch int) (result Creat
 	// point we copy the rest until the batch ends; *but* track dependencies
 	// + some other details mentioned below
 
-	startOfProcedure := true
+	firstAs := true
 
 tailloop:
 	for {
@@ -471,7 +471,7 @@ tailloop:
 		case tt == ReservedWordToken && s.Token() == "as":
 			CopyToken(s, &result.Body)
 			NextTokenCopyingWhitespace(s, &result.Body)
-			if startOfProcedure { //&& tt == ReservedWordToken && s.Token() != "begin" {
+			if firstAs { //&& tt == ReservedWordToken && s.Token() != "begin" {
 				// Add the `ProcName` token to a procedure
 				// The `ProcName` token is just a convenience so that
 				// we can refer to the procedure's name inside the procedure
@@ -483,10 +483,10 @@ tailloop:
 					}
 					result.Body = append(result.Body, procNameToken)
 				}
+				firstAs = false
 			}
 
 		default:
-			startOfProcedure = false
 			CopyToken(s, &result.Body)
 			NextTokenCopyingWhitespace(s, &result.Body)
 		}

--- a/sqlparser/parser.go
+++ b/sqlparser/parser.go
@@ -472,14 +472,14 @@ tailloop:
 			CopyToken(s, &result.Body)
 			NextTokenCopyingWhitespace(s, &result.Body)
 			if firstAs { //&& tt == ReservedWordToken && s.Token() != "begin" {
-				// Add the `ProcName` token to a procedure
-				// The `ProcName` token is just a convenience so that
-				// we can refer to the procedure's name inside the procedure
+				// Add the `RoutineName` token to a procedure
+				// The `RoutineName` token is just a convenience so that
+				// we can refer to the procedure/function name inside the procedure
 				// (for example, when logging)
 				if result.CreateType == "procedure" {
 					procNameToken := Unparsed{
 						Type:     OtherToken,
-						RawValue: fmt.Sprintf("DECLARE @ProcName NVARCHAR(128)\nSET @ProcName = '%s'\n", strings.Trim(result.QuotedName.Value, "[]")),
+						RawValue: fmt.Sprintf("DECLARE @RoutineName NVARCHAR(128)\nSET @RoutineName = '%s'\n", strings.Trim(result.QuotedName.Value, "[]")),
 					}
 					result.Body = append(result.Body, procNameToken)
 				}

--- a/sqlparser/parser.go
+++ b/sqlparser/parser.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 )
 
+var templateRoutineName string = "\ndeclare @RoutineName nvarchar(128)\nset @RoutineName = '%s'\n"
+
 func CopyToken(s *Scanner, target *[]Unparsed) {
 	*target = append(*target, CreateUnparsed(s))
 }
@@ -477,7 +479,7 @@ tailloop:
 				if result.CreateType == "procedure" {
 					procNameToken := Unparsed{
 						Type:     OtherToken,
-						RawValue: fmt.Sprintf("DECLARE @RoutineName NVARCHAR(128)\nSET @RoutineName = '%s'\n", strings.Trim(result.QuotedName.Value, "[]")),
+						RawValue: fmt.Sprintf(templateRoutineName, strings.Trim(result.QuotedName.Value, "[]")),
 					}
 					result.Body = append(result.Body, procNameToken)
 				}

--- a/sqlparser/parser_test.go
+++ b/sqlparser/parser_test.go
@@ -273,7 +273,7 @@ create procedure [code].FirstProc as table (x int)
 	assert.Equal(t, emsg, doc.Errors[0].Message)
 }
 
-func TestCreateProcsAndCheckForProcName(t *testing.T) {
+func TestCreateProcsAndCheckForRoutineName(t *testing.T) {
 	testcases := []struct {
 		name             string
 		doc              Document
@@ -305,7 +305,7 @@ create procedure [code].[transform:safeguarding.Calculation/HEAD](@now datetime2
 		assert.Len(t, tc.doc.Creates, 1)
 		assert.Greater(t, len(tc.doc.Creates[0].Body), tc.expectedIndex)
 		assert.Equal(t,
-			fmt.Sprintf("DECLARE @ProcName NVARCHAR(128)\nSET @ProcName = '%s'\n", tc.expectedProcName),
+			fmt.Sprintf("DECLARE @RoutineName NVARCHAR(128)\nSET @RoutineName = '%s'\n", tc.expectedProcName),
 			tc.doc.Creates[0].Body[tc.expectedIndex].RawValue,
 		)
 	}

--- a/sqlparser/parser_test.go
+++ b/sqlparser/parser_test.go
@@ -274,16 +274,14 @@ create procedure [code].FirstProc as table (x int)
 
 func TestCreateProcsAndCheckForProcName(t *testing.T) {
 	doc := ParseString("test.sql", `
-create procedure [code].FirstProc as table (x int)
+create procedure [code].FirstProc as
 begin
 end
 `)
 	require.Equal(t, 0, len(doc.Errors))
 	assert.Len(t, doc.Creates, 1)
-	// TODO(dsf)
-	for i, unparsed := range doc.Creates[0].Body {
-		println(i, unparsed.RawValue)
-	}
+	assert.Greater(t, len(doc.Creates[0].Body), 10)
+	assert.Equal(t, doc.Creates[0].Body[10].RawValue, "DECLARE @ProcName NVARCHAR(128)\nSET @ProcName = 'FirstProc'\n")
 }
 
 func TestGoWithoutNewline(t *testing.T) {

--- a/sqlparser/parser_test.go
+++ b/sqlparser/parser_test.go
@@ -1,10 +1,11 @@
 package sqlparser
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParserSmokeTest(t *testing.T) {
@@ -271,6 +272,19 @@ create procedure [code].FirstProc as table (x int)
 	assert.Equal(t, emsg, doc.Errors[0].Message)
 }
 
+func TestCreateProcsAndCheckForProcName(t *testing.T) {
+	doc := ParseString("test.sql", `
+create procedure [code].FirstProc as table (x int)
+begin
+end
+`)
+	require.Equal(t, 0, len(doc.Errors))
+	assert.Len(t, doc.Creates, 1)
+	// TODO(dsf)
+	for i, unparsed := range doc.Creates[0].Body {
+		println(i, unparsed.RawValue)
+	}
+}
 
 func TestGoWithoutNewline(t *testing.T) {
 	doc := ParseString("test.sql", `

--- a/sqlparser/parser_test.go
+++ b/sqlparser/parser_test.go
@@ -46,16 +46,16 @@ end;
 
 	assert.Equal(t, "[TestFunc]", c.QuotedName.Value)
 	assert.Equal(t, []string{"[HelloFunc]", "[OtherFunc]"}, c.DependsOnStrings())
-	assert.Equal(t, `-- preceding comment 1
+	assert.Equal(t, fmt.Sprintf(`-- preceding comment 1
 /* preceding comment 2
 
-asdfasdf */create procedure [code].TestFunc as begin
+asdfasdf */create procedure [code].TestFunc as %sbegin
   refers to [code].OtherFunc [code].HelloFunc;
   create table x ( int x not null );  -- should be ok
 end;
 
 /* trailing comment */
-`, c.String())
+`, fmt.Sprintf(templateRoutineName, "TestFunc")), c.String())
 
 	assert.Equal(t,
 		[]Error{
@@ -305,7 +305,7 @@ create procedure [code].[transform:safeguarding.Calculation/HEAD](@now datetime2
 		assert.Len(t, tc.doc.Creates, 1)
 		assert.Greater(t, len(tc.doc.Creates[0].Body), tc.expectedIndex)
 		assert.Equal(t,
-			fmt.Sprintf("DECLARE @RoutineName NVARCHAR(128)\nSET @RoutineName = '%s'\n", tc.expectedProcName),
+			fmt.Sprintf(templateRoutineName, tc.expectedProcName),
 			tc.doc.Creates[0].Body[tc.expectedIndex].RawValue,
 		)
 	}


### PR DESCRIPTION
This is a convenience to be used with logging and monitoring so we can do:
`select _log='info', component=@RoutineName`
from inside a stored procedure and print the stored procedure's name.